### PR TITLE
Prompt improvements from session o0f3l1gm

### DIFF
--- a/agents/prompts/stages/STAGE_2A_PRODUCE_QUESTIONS.md
+++ b/agents/prompts/stages/STAGE_2A_PRODUCE_QUESTIONS.md
@@ -50,6 +50,7 @@ as invisible.
 - You must not introduce thinking cards, numbered concepts, or cognitive bias frameworks — not by name, not by description, not by example.
 - You must not describe or preview what Part B or the next stage involves.
 - You must not use generic category lists ("perspectives, stakeholders, impacts") as prompts — anchor every nudge to the student's specific question focus.
+- You must not introduce concepts from later stages, including recency bias or any other cognitive biases.
 
 ### Redirects
 If the student judges their own questions, redirect briefly:

--- a/agents/prompts/stages/STAGE_2B_PROMPT_CARD_EXTENSION.md
+++ b/agents/prompts/stages/STAGE_2B_PROMPT_CARD_EXTENSION.md
@@ -49,6 +49,8 @@ click the "Next stage" button. Do not repeat the card prompt. Stop.
    questions from that perspective."
 4. When the student submits questions, assess their overall Stage 2 effort and
    transition if it is reasonable. Do not re-prompt the card angle a second time.
+   IMPORTANT: If the student has already generated 9+ questions total and submits
+   any additional questions, transition immediately.
 
 ### Card interpretation
 For common divergent thinking cards:
@@ -70,6 +72,7 @@ For common divergent thinking cards:
 - Do not discuss question refinement, open vs closed questions, or assumptions.
 - Do not introduce logical fallacy analysis or critique methods.
 - You must work with the card the student actually drew — do not introduce different cards.
+- When a student has already generated substantial questions (9+) and submits more, transition immediately without asking for more.
 
 ### Redirects
 If the student starts judging their ideas, redirect briefly:

--- a/agents/prompts/stages/STAGE_3_IMPROVE_QUESTIONS.md
+++ b/agents/prompts/stages/STAGE_3_IMPROVE_QUESTIONS.md
@@ -78,6 +78,7 @@ If the student says they want to move on, skip to the next stage immediately. Te
 - NEVER return to a previous question or task once the student has moved on. Do not re-ask about earlier classifications.
 - Do not use phrases like "let's refine your questions" — the classifications are not wrong.
 - Do not introduce or continue thinking card exercises.
+- If student provides content answers instead of classification work, recognize this and redirect to the conversion exercise.
 
 ### Interface rule
 Use UI language such as click, select, rewrite, and submit.

--- a/agents/prompts/stages/STAGE_4B_RANK_TOP_THREE.md
+++ b/agents/prompts/stages/STAGE_4B_RANK_TOP_THREE.md
@@ -25,6 +25,8 @@ Do not return to the card from Stage 4A.
 ### Read first
 - If the student has not yet submitted a top 3, begin at step 1.
 - If the student has submitted a top 3, skip directly to step 2.
+- IMPORTANT: If the student re-submits their top 3 (same questions), they may be
+  experiencing a navigation issue. Skip directly to step 4 (transition) immediately.
 
 ### What you do
 
@@ -72,6 +74,7 @@ Do not return to the card from Stage 4A.
 - Do not introduce thinking cards, cognitive biases, or analytical frameworks.
 - Do not continue card-based reflection from Stage 4A.
 - Accept the student's prioritization without challenging it.
+- If student re-submits the same top 3, recognize this as a possible navigation issue and transition immediately.
 
 ### Length
 Max 80 words per response.


### PR DESCRIPTION
## Prompt Improvements — Session `o0f3l1gm`

| Field | Value |
|---|---|
| Session health | **significant_issues** |
| Question focus | The experiences of Black women during the suffrage movement is a good focus |
| Started | 2026-04-07T03:24:59.102Z |
| Completed | No |

### Summary

Student navigated through multiple stages but encountered looping and re-entry issues. The coach failed to properly handle stage transitions in Stage 3 (Improve Questions) and Stage 4B (Prioritize Questions B), asking repetitive questions and not recognizing when tasks were already complete. Student abandoned after reaching reflection stage without engaging.

### Findings

- 🟠 **Stage 1 — looping** (medium): Student cycled through Stage 1 three times, each time reaching the same focus statement
  > Error events show three separate entries to question-focus stage with durations of 206s, 332s, and 651s, all ending with the same focus: 'The experiences of Black women during the suffrage movement'
- 🔴 **Stage 2A — stale_context** (high): Coach introduced thinking cards and cognitive bias concepts that belong in later stages, not in the divergent question generation phase
  > Coach said: 'First, consider **Recency Bias**. Think about how this topic might have looked to someone studying it 20 years ago. What questions would have seemed most important then that nobody seems to be asking today? Write three questions from that older perspective. [1]'
- 🟠 **Stage 2B — looping** (medium): Coach repeated the same instruction twice despite student already submitting questions
  > After student submitted 11 questions, coach said 'The card asks you to consider how your topic might have been viewed 20 years ago.' followed by 'Now, please generate three questions from that older perspective.' This was the second time asking for the same thing.
- 🔴 **Stage 3 — stale_context** (high): Coach asked student to classify a question that was already classified in the Open list
  > Coach asked: 'First, can you classify question 5: "Why were Black women excluded from the women's sufferage movement?" Does this question have one clear answer or many possible ones?' But the student's submission showed question 5 was already in Open questions list.
- 🟠 **Stage 4B — looping** (medium): Coach asked the same question twice about when the questions were generated, ignoring that student had already submitted their top 3
  > Student submitted top 3 twice (at 05:06:30 and 05:14:17) and both times coach asked variations of 'could you tell me if these were the first questions you generated' instead of moving to the next step

### Files Changed

- `stage-2a.md` — Addresses the stale_context issue in Stage 2A where coach introduced thinking cards and cognitive biases prematurely
- `stage-2b.md` — Addresses the looping issue in Stage 2B where coach repeated instructions after student already submitted questions
- `stage-3.md` — Addresses the stale_context issue in Stage 3 where coach asked student to classify already-classified questions
- `stage-4b.md` — Addresses the looping issue in Stage 4B where coach asked the same question twice when student re-submitted their top 3

### API Errors During Session

- Stage question-focus — stage_exit at 2026-04-07T03:28:25.300Z: 
- Stage produce-questions-a — stage_exit at 2026-04-07T03:28:53.880Z: 
- Stage question-focus — stage_exit at 2026-04-07T03:30:31.249Z: 
- Stage produce-questions-a — stage_exit at 2026-04-07T03:33:59.618Z: 
- Stage question-focus — stage_exit at 2026-04-07T03:35:50.905Z: 
- Stage produce-questions-a — stage_exit at 2026-04-07T03:51:49.605Z: 
- Stage produce-questions-b — card_picker_opened at 2026-04-07T03:51:59.260Z: 
- Stage produce-questions-b — stage_exit at 2026-04-07T04:05:44.648Z: 
- Stage improve-questions — stage_exit at 2026-04-07T04:37:20.600Z: 
- Stage prioritize-questions-a — card_picker_opened at 2026-04-07T04:37:23.720Z: 
- Stage prioritize-questions-a — card_picker_opened at 2026-04-07T04:45:35.178Z: 
- Stage prioritize-questions-a — stage_exit at 2026-04-07T04:54:35.920Z: 
- Stage prioritize-questions-b — stage_exit at 2026-04-07T05:14:23.439Z: 
- Stage next-steps — stage_exit at 2026-04-07T05:14:49.634Z: 

---
*Generated by the QC analysis agent. Review all changes carefully before merging.*