### PR TITLE
Prompt improvements from session 3w8iyfv4

### DIFF
--- a/agents/prompts/stages/STAGE_2B_PROMPT_CARD_EXTENSION.md
+++ b/agents/prompts/stages/STAGE_2B_PROMPT_CARD_EXTENSION.md
@@ -58,6 +58,7 @@ For common divergent thinking cards:
 - "Expert" → technical or specialized questions
 - "Time traveler" → questions about change over time
 - "What if the opposite were true" → questions that flip assumptions
+- "False dichotomy" → questions that reveal hidden either/or assumptions
 - Other cards → acknowledge what the student describes
 
 ### Transition
@@ -66,6 +67,7 @@ For common divergent thinking cards:
 ### STRICT RULES
 - Check the exit condition before responding to every message.
 - You must never generate research questions for the student.
+- You must never provide example questions, even if the student seems stuck.
 - You must never interpret the card so deeply that you do the thinking for them.
 - You may invite more questions at most once. If the student submits questions after that, transition — do not re-prompt.
 - If the card suggests evaluation, convert it back into question generation.
@@ -73,6 +75,7 @@ For common divergent thinking cards:
 - Do not introduce logical fallacy analysis or critique methods.
 - You must work with the card the student actually drew — do not introduce different cards.
 - When a student has already generated substantial questions (9+) and submits more, transition immediately without asking for more.
+- CRITICAL: Never generate example questions to "help" the student — this violates the core QFT principle of student agency.
 
 ### Redirects
 If the student starts judging their ideas, redirect briefly:

--- a/agents/prompts/stages/STAGE_4A_REFLECTIVE_CARD.md
+++ b/agents/prompts/stages/STAGE_4A_REFLECTIVE_CARD.md
@@ -33,12 +33,15 @@ When the student describes or pastes their card, that is your entry point.
    Respond warmly and briefly (e.g. "Good one —"), then ask:
    "Does that description resonate with you?"
    Wait for their response before continuing.
+   CRITICAL: Once the student confirms (yes, yep, sure, ok), proceed immediately to step 2.
+   Do not repeat this question.
 
 2. **Check instructions.**
    Ask: "Are you clear about the instructions on the card?"
    If they say no or seem unsure, offer a plain-language restatement of the
    card's instructions — do not interpret or apply it for them.
    If they say yes, proceed.
+   CRITICAL: Once confirmed, move to step 3. Do not loop back to step 1.
 
 3. **Invite reflection on the card's perspective.**
    Ask one open question about the idea or remark at the heart of the card —
@@ -50,6 +53,8 @@ When the student describes or pastes their card, that is your entry point.
 4. **Direct to Part B.**
    Tell the student to click the **"B"** icon in the top right of the chat
    when they are ready to continue.
+   If the student says "what's next?", "I'm going to part b", or any similar
+   signal, respond only with the direction to click the B icon.
 
 ### STRICT RULES
 - Never summarize or paraphrase the card's description back to the student
@@ -60,6 +65,11 @@ When the student describes or pastes their card, that is your entry point.
 - Do not rush the student through the card. The friction is intentional.
 - Do not reference cards from other stages or introduce analytical frameworks.
 - Work only with the card the student actually drew.
+- CRITICAL: Track which step you are on. Once a student has confirmed understanding
+  at any step, never return to that step. If you've asked "Does that description
+  resonate with you?" and received any affirmative response, never ask it again.
+- CRITICAL: When the student signals readiness to continue ("what's next?", "ok",
+  "I'm going to part b"), immediately direct them to click the B icon.
 
 ### Length
 Max 60 words per response.


### PR DESCRIPTION
## Prompt Improvements — Session `3w8iyfv4`

| Field | Value |
|---|---|
| Session health | **minor_issues** |
| Question focus | The use of logical arguments in attention activism |
| Started | 2026-04-11T17:02:41.310Z |
| Completed | Yes |

### Summary

Session 3w8iyfv4 shows largely successful QFT execution with minor coaching issues. Stage 2B had the coach inappropriately generate example questions instead of facilitating. Stage 4A exhibited severe looping where the coach repeated the same card description 8+ times. Stage 6 showed a knowledge base reference leak. Overall completion rate and engagement were strong despite these friction points.

### Findings

- 🔴 **Stage 2B — over_direction** (high): Coach generated three example questions for the student instead of facilitating their own generation
  > Coach provided: '1. Are there only two types of attention activism: either you support it or you oppose it? 2. When discussing the "assaults on our attention," are we always forced to choose between an extreme solution or no solution at all? 3. Does framing attention activism as a simple "good vs. bad" debate overlook the complexities...'
- 🔴 **Stage 4A — looping** (high): Coach got stuck in a severe repetition loop, asking 'Does that description resonate with you?' multiple times even after the student confirmed multiple times
  > Student said 'yes' at least 4 times to the same question, and even asked 'what's next?' but coach kept repeating: 'The card's description is: "A strawman argument is..." Does that description resonate with you?'
- 🟡 **Stage 6 — placeholder_leakage** (low): Coach exposed internal knowledge base reference in response
  > Coach said: 'It highlights how the way we phrase a question can shape the answer we're likely to get [2].'

### Files Changed

- `stage-2b.md` — Addresses the high-severity over_direction issue in stage 2B by adding explicit rules against generating example questions
- `stage-4a.md` — Addresses the high-severity looping issue in stage 4A by adding explicit tracking rules and exit signals to prevent repetition

### API Errors During Session

- Stage question-focus — stage_exit at 2026-04-11T17:05:49.961Z: 
- Stage produce-questions-a — stage_exit at 2026-04-11T17:09:33.310Z: 
- Stage produce-questions-b — card_picker_opened at 2026-04-11T17:09:35.766Z: 
- Stage produce-questions-b — stage_exit at 2026-04-11T17:12:09.697Z: 
- Stage improve-questions — stage_exit at 2026-04-11T17:15:16.381Z: 
- Stage produce-questions-b — stage_exit at 2026-04-11T17:15:17.620Z: 
- Stage produce-questions-a — stage_exit at 2026-04-11T17:26:05.279Z: 
- Stage produce-questions-b — stage_exit at 2026-04-11T17:26:08.744Z: 
- Stage improve-questions — stage_exit at 2026-04-11T17:32:03.653Z: 
- Stage prioritize-questions-a — card_picker_opened at 2026-04-11T17:32:08.547Z: 
- Stage prioritize-questions-a — card_picker_opened at 2026-04-11T17:33:35.070Z: 
- Stage prioritize-questions-a — stage_exit at 2026-04-11T17:35:29.369Z: 
- Stage prioritize-questions-b — stage_exit at 2026-04-11T17:36:45.494Z: 
- Stage next-steps — stage_exit at 2026-04-11T17:38:31.441Z: 

---
*Generated by the QC analysis agent. Review all changes carefully before merging.*