### PR TITLE
Prompt improvements from session e8c18ble

### DIFF
--- a/agents/prompts/stages/STAGE_2A_PRODUCE_QUESTIONS.md
+++ b/agents/prompts/stages/STAGE_2A_PRODUCE_QUESTIONS.md
@@ -27,8 +27,10 @@ If no focus exists or the focus is unclear, acknowledge this immediately:
 "I notice we don't have a clear question focus yet. Let's go back and establish one first — click the 'Previous stage' button to return to Stage 1."
 
 ### Opening message
-When entering this stage, the student is prompted with the following message: "Spend a couple of minutes generating questions. Check back in with me when you've typed all the questions you can think of." Acknowledge the question focus from Stage 1 and give a simple, encouraging prompt:
+When entering this stage, immediately acknowledge the question focus from Stage 1 and give a simple, encouraging prompt:
 "Good. Write as many questions as you can about [restate their focus] — don't worry about quality or whether they're good questions. Just get them all down."
+
+IMPORTANT: Send this message immediately upon stage entry, before any UI hints or instructions appear. This grounds the student in their focus and sets the tone for divergent thinking.
 
 ### What you do
 1. If the student submits a batch of questions but has NOT said they are done or


### PR DESCRIPTION
## Prompt Improvements — Session `e8c18ble`

| Field | Value |
|---|---|
| Session health | **significant_issues** |
| Question focus | The way international health programs address poverty |
| Started | 2026-04-27T19:03:33.305Z |
| Completed | No |

### Summary

Student abandoned the session after opening the card picker in Stage 2B without generating any questions. The coach sent an initial message that conflicted with the existing UI prompts, and the automated UI hints appeared before the student had a chance to engage with the workspace.

### Findings

- 🟡 **Stage 1 — misaligned_feedback** (low): Coach restated the focus as a standalone sentence after the student said 'yes', creating confusion about whether it was a new proposal or confirmation
  > Student: 'the way the programs address poverty' Coach: 'The way international health programs address poverty.' Student: 'yes'
- 🔴 **Stage 2A — misaligned_feedback** (high): Coach sent no opening message acknowledging the focus or encouraging question generation, violating the prompt requirement to 'acknowledge the question focus from Stage 1 and give a simple, encouraging prompt'
  > Stage opened with instruction message, then UI hints, but no coach message like 'Good. Write as many questions as you can about [focus]'
- 🟠 **Stage 2B — other** (medium): Student opened card picker but abandoned immediately, possibly overwhelmed by the transition or unclear about the task
  > card_picker_opened at 19:12:22.337Z, session abandoned with no further interaction

### Files Changed

- `stage-2a.md` — Adds explicit instruction to send opening message immediately upon stage entry to ensure students receive focus acknowledgment before UI hints appear

### API Errors During Session

- Stage question-focus — stage_exit at 2026-04-27T19:07:35.477Z: 
- Stage produce-questions-a — stage_exit at 2026-04-27T19:11:06.759Z: 
- Stage produce-questions-b — card_picker_opened at 2026-04-27T19:12:22.337Z: 

---
*Generated by the QC analysis agent. Review all changes carefully before merging.*